### PR TITLE
Add a cronjob to purge agents daily

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -3,3 +3,7 @@ nessus-manager/Nessus-6.7.0-ubuntu1110_amd64.deb:
   object_id: e21a48f1-61d9-4dfd-98a4-8fb80ac8341e
   sha: 183d4e9dcaeb184cd20c579fa66106ab185c9ef5
   size: 32669834
+jq/jq-1.5.gz:
+  object_id: 6c933704-2057-4fa6-938b-ae67d9d51e30
+  sha: 2e281d558b5d2c4695f9a9de87dca70d3e7cdc16
+  size: 1364760

--- a/jobs/nessus-manager/spec
+++ b/jobs/nessus-manager/spec
@@ -2,6 +2,7 @@
 name: nessus-manager
 packages:
 - nessus-manager
+- jq-1.5
 properties:
   nessus-manager.license:
     description: "[required] Nessus Manager license key"
@@ -14,8 +15,10 @@ properties:
     default: SaMpLePaSs+2016
 templates:
   bin/ctl: bin/ctl
-  bin/monit_debugger: bin/monit_debugger
   bin/health.sh: bin/health.sh
+  bin/monit_debugger: bin/monit_debugger
+  bin/purge-agents.sh: bin/purge-agents.sh
+  config/crontab: config/crontab
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh.erb: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh

--- a/jobs/nessus-manager/templates/bin/ctl
+++ b/jobs/nessus-manager/templates/bin/ctl
@@ -11,6 +11,10 @@ export LANG=en_US.UTF-8
 case $1 in
 
   start)
+    # install a cronjob to purge agents
+    cp ${JOB_DIR}/config/crontab /etc/cron.d/${JOB_NAME}
+    touch /etc/crontab
+
     pid_guard $PIDFILE $JOB_NAME
 
     NESSUS_HOME="/var/vcap/store/nessus-manager/opt/nessus"

--- a/jobs/nessus-manager/templates/bin/purge-agents.sh
+++ b/jobs/nessus-manager/templates/bin/purge-agents.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# where is jq?
+JQ=/var/vcap/packages/jq-1.5/bin/jq
+
+# where is nessus?
+NESSUS_URL=https://localhost:8834
+
+
+# authenticate and grab the token
+TOKEN=$(curl -s -k -X POST -H 'Content-Type: application/json' -d '{"username":"<%= p("nessus-manager.username") %>","password":"<%= p("nessus-manager.password") %>"}' ${NESSUS_URL}/session | ${JQ} -r .token)
+
+# make a curl request to the nessus api using token based auth
+napi() {
+    if [ ! -z "${2}" ]; then
+        METHOD="-X ${2}"
+    else
+        METHOD="-X GET"
+    fi
+
+    # yes nessus uses it's own special header called X-Cookie :/
+    curl -s -k ${METHOD} -H "X-Cookie: token=${TOKEN};" ${NESSUS_URL}${1}
+}
+
+# iterate through all our agents and unlink them
+for sid in $(napi /scanners | ${JQ} .scanners[].id); do
+    for aid in $(napi /scanners/${sid}/agents | ${JQ} -r .agents[].id); do
+        napi /scanners/${sid}/agents/${aid} DELETE
+    done
+done

--- a/jobs/nessus-manager/templates/config/crontab
+++ b/jobs/nessus-manager/templates/config/crontab
@@ -1,0 +1,3 @@
+# m h dom mon dow user command
+# purge all our agents before our daily scans run, the agents will relink themselves at the bottom of the hour
+20 0 * * * root /var/vcap/jobs/nessus-manager/bin/purge-agents.sh


### PR DESCRIPTION
*BEFORE MERGING THIS!*: ensure that https://github.com/18F/cg-nessus-agent-boshrelease/pull/7 is merged and deployed to all VMs first.  That PR ensures that the agents continually try to relink themselves with the manager.

This PR will remove all agents from nessus each day so that only the active agents (which will relink themselves via the PR above) will be scanned and count against our limited license pool.
