### PR TITLE
Emit nessus scans and host vulns to logs.

### DIFF
--- a/jobs/nessus-manager/spec
+++ b/jobs/nessus-manager/spec
@@ -18,6 +18,7 @@ templates:
   bin/health.sh: bin/health.sh
   bin/monit_debugger: bin/monit_debugger
   bin/purge-agents.sh: bin/purge-agents.sh
+  bin/emit-scans.sh: bin/emit-scans.sh
   config/crontab: config/crontab
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh.erb: helpers/ctl_setup.sh

--- a/jobs/nessus-manager/templates/bin/emit-scans.sh
+++ b/jobs/nessus-manager/templates/bin/emit-scans.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eux
+
+export PATH=$PATH:/var/vcap/packages/jq-1.5/bin
+
+rm -f /var/vcap/sys/log/nessus-manager/scans.log
+rm -f /var/vcap/sys/log/nessus-manager/hosts.log
+
+token=$(curl -sk -X POST \
+  https://127.0.0.1:8834/session \
+  -H 'Content-Type: application/json' \
+  -d @<(cat <<EOF
+{
+  "username": "<%= p("nessus-manager.username") %>",
+  "password": "<%= p("nessus-manager.password") %>"
+}
+EOF
+) | jq -r ".token")
+
+for scanid in $(curl -sk https://127.0.0.1:8834/scans \
+    -H "X-Cookie: token=${token}" \
+    | jq -r ".scans[] | .id"); do
+  scan=$(curl -sk "https://127.0.0.1:8834/scans/${scanid}" \
+    -H "X-Cookie: token=${token}")
+  echo "${scan}" | jq -rc "del(.. | .history?) | del(.. | .plugin_set?)" >> /var/vcap/sys/log/nessus-manager/scans.log
+  echo >> /var/vcap/sys/log/nessus-manager/scans.log
+  for host in $(echo "${scan}" | jq -r ".hosts[] | .host_id"); do
+    curl -sk "https://127.0.0.1:8834/scans/${scanid}/hosts/${host}" \
+      -H "X-Cookie: token=${token}" \
+      >> /var/vcap/sys/log/nessus-manager/hosts.log
+    echo >> /var/vcap/sys/log/nessus-manager/hosts.log
+  done
+done

--- a/jobs/nessus-manager/templates/config/crontab
+++ b/jobs/nessus-manager/templates/config/crontab
@@ -1,3 +1,4 @@
 # m h dom mon dow user command
 # purge all our agents before our daily scans run, the agents will relink themselves at the bottom of the hour
 20 0 * * * root /var/vcap/jobs/nessus-manager/bin/purge-agents.sh
+0 3 * * * root /var/vcap/jobs/nessus-manager/bin/emit-scans.sh


### PR DESCRIPTION
So that we can eventually clear out old nessus scans, and to satisfy a compliance need to correlate logs across systems.