### PR TITLE
Delete old scan history.

### DIFF
--- a/jobs/nessus-manager/spec
+++ b/jobs/nessus-manager/spec
@@ -5,14 +5,14 @@ packages:
 - jq-1.5
 properties:
   nessus-manager.license:
-    description: "[required] Nessus Manager license key"
-    default: EVAL-AAAA-BBBB-CCCC-DDDD
+    description: "Nessus Manager license key"
   nessus-manager.username:
-    description: "[required] Nessus Manager initial admin user"
-    default: admin
+    description: "Nessus Manager initial admin user"
   nessus-manager.password:
-    description: "[required] Nessus Manager initial password"
-    default: SaMpLePaSs+2016
+    description: "Nessus Manager initial password"
+  nessus-manager.expiration-days:
+    description: Number of days to retain scans
+    default: 90
 templates:
   bin/ctl: bin/ctl
   bin/health.sh: bin/health.sh


### PR DESCRIPTION
So the nessus manager disk stops filling up. @brittag pointed out that

> RA-5 says “Scan results and logs are kept for at least 60 days (with a monthly export kept indefinitely in Google Drive) for comparison to previous reports.”

So it should be safe to delete old scan history from the nessus manager.