### PR TITLE
README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 These examples use [bosh-lite](https://github.com/cloudfoundry/bosh-lite).
 
 Target bosh and clone the repo
-```
-bosh target 192.168.50.4
+
+```sh
+bosh -e vbox env
 git clone https://github.com/18F/cg-nessus-manager-boshrelease.git
 ```
 
@@ -14,28 +15,25 @@ Download the Nessus deb package from http://www.tenable.com
 
 Add the Nessus deb package as a blob
 
-```
+```sh
 cd cg-nessus-manager-boshrelease
-bosh add blob path/to/Nessus*.deb nessus-manager
+bosh -e vbox add-blob path/to/Nessus*.deb nessus-manager
 ```
 
 Create and upload a release
-```
-bosh create release --force
-bosh upload release
+
+```sh
+bosh -e vbox create-release --force
+bosh -e vbox upload-release
 ```
 
-Set deployment manifest
-```
-bosh deployment manifests/bosh-lite.yml
+Deploy using the manifest
+
+```sh
+bosh -e vbox -d nessus-manager manifests/bosh-lite.yml
 ```
 
-Deploy
-```
-bosh deploy
-```
-
---
+---
 
 A license key and administrator credentials are required.  Note that although a license key is required by this release, it can be an invalid key; A valid key can be entered later with the `nessuscli` command line utility.
 
@@ -43,5 +41,4 @@ For configuration information, see the spec at `jobs/nessus-manager/spec` and ex
 
 Nessus resides on a persistent disk; size the disk accordingly.
 
-After deployment, the web UI is available at https://10.244.18.2:8834 (for a bosh-lite deployment) with an SSL certificate signed by Nessus Certification Authority.
-
+After deployment, the web UI is available at https://10.244.18.2:8834 (for a `bosh-lite` deployment) with an SSL certificate signed by Nessus Certification Authority.


### PR DESCRIPTION
- Uses bosh-lite's examples of using `bosh -e vbox` for env targeting
- Adds markdown parsing directives in code blocks
- Adds updated bosh2 cli commands for examples
- Adds missing `-` in the triple-dash block