### PR TITLE
README including example of local blobstore testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ bosh target 192.168.50.4
 git clone https://github.com/18F/cg-nessus-manager-boshrelease.git
 ```
 
+For local testing, set the `blobstore` provider to [`local` in the `config/final.yml`](https://bosh.io/docs/release-blobstore/#local-config). Your `final.yml` should look similar to this:
+
+```yml
+---
+final_name: nessus-manager
+blobstore:
+  provider: local
+  options:
+    blobstore_path: /tmp/test-blobs
+```
+
 Download the Nessus deb package from http://www.tenable.com
 
 Add the Nessus deb package as a blob
@@ -44,4 +55,3 @@ For configuration information, see the spec at `jobs/nessus-manager/spec` and ex
 Nessus resides on a persistent disk; size the disk accordingly.
 
 After deployment, the web UI is available at https://10.244.18.2:8834 (for a bosh-lite deployment) with an SSL certificate signed by Nessus Certification Authority.
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bosh target 192.168.50.4
 git clone https://github.com/18F/cg-nessus-manager-boshrelease.git
 ```
 
-For local testing, set the `blobstore` provider to [`local` in the `config/final.yml`](https://bosh.io/docs/release-blobstore/#local-config). Your `final.yml` should look similar to this:
+For creating the release, either set the blobstore [`config/final.yml` to an s3 bucket](https://bosh.io/docs/release-blobstore/#s3-config) you own, [or if building on your own machine, you could set it to `local`](https://bosh.io/docs/release-blobstore/#local-config). If you're using `local`, your `config/final.yml` may look similar to this:
 
 ```yml
 ---


### PR DESCRIPTION
When creating this boshrelease locally w/o usage of the 18f s3 bucket, the `blobstore` provider should either be changed or set to `local` rather than trying to use the 18f bucket (which doesn't seem to exist anymore...?). Provided example of setting this in the README. https://bosh.io/docs/release-blobstore/#local-config